### PR TITLE
Expose syntheticUsageRatio as Prometheus metric

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,6 +37,7 @@ import (
 	scalingv1alpha1 "github.com/jpztech/hpa-admin-controller/api/v1alpha1"
 	"github.com/jpztech/hpa-admin-controller/internal/controller"
 	//+kubebuilder:scaffold:imports
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 var (
@@ -49,6 +50,9 @@ func init() {
 
 	utilruntime.Must(scalingv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
+
+	// Register custom metrics with the global Prometheus registry
+	metrics.Registry.MustRegister(controller.SyntheticUsageRatioMetric)
 }
 
 func main() {


### PR DESCRIPTION
This commit introduces a new Prometheus Gauge metric named `syntheticUsageRatio`. This metric is exposed by the controller and includes labels `apiVersion`, `kind`, and `name` derived from the `scaleTargetRef` of the SynthenticMetric resource.

The metric is registered with the controller-runtime's metric registry and updated during the reconciliation loop after the `syntheticUsageRatio` is calculated.

Unit tests have been updated to verify that the metric is correctly exposed with the appropriate labels and value.